### PR TITLE
2.2.4 增加默认关灯模式

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 // ==UserScript==
 // @name         纯净版斗鱼（douyu）
 // @namespace    https://github.com/ljezio
-// @version      2.2.2
-// @description  斗鱼纯净版（douyu.com），只保留直播和弹幕【斗鱼精简版、斗鱼极简版、斗鱼清爽版】
+// @version      2.2.4
+// @description  斗鱼纯净版（douyu.com），只保留直播和弹幕，并提供关灯模式【斗鱼精简版、斗鱼极简版、斗鱼清爽版】
 // @homepage     https://github.com/ljezio/pure-douyu
 // @author       ljezio
 // @license      MIT
@@ -13,6 +13,11 @@
 
 (function () {
     'use strict';
+
+    // 通过注入CSS的方式强制设置背景为纯黑色，避免被网站原有样式覆盖
+    const style = document.createElement('style');
+    style.innerHTML = 'html, body { background-color: #000 !important; }';
+    document.head.appendChild(style);
 
     const player = document.querySelector('.layout-Player');
     const root = document.querySelector('#root') ||


### PR DESCRIPTION
你好，作者！

非常感谢你开发和维护这个超棒的脚本，它极大地改善了斗鱼的观看体验。

在使用过程中，我发现如果能像视频网站的“关灯”功能一样，让播放器以外的区域变成纯黑色，沉浸感会更强。于是我动手修改了一下代码。

主要的改动是：

    通过在 <head> 中注入 <style> 标签的方式，强制将 <html> 和 <body> 的背景色设置为黑色。

    使用 !important 确保这个样式能覆盖掉斗鱼网站原有的样式，保证了在各种情况下都能生效。

希望这个小改进能让脚本变得更好。期待你的回复！
改动前：
<img width="1885" height="998" alt="图片" src="https://github.com/user-attachments/assets/8ea4b7ac-ebc8-48cb-988b-dc4a8891886d" />
改动后：
<img width="1883" height="988" alt="图片" src="https://github.com/user-attachments/assets/4ce7bc0c-634f-4115-976d-fa36a12c9cdb" />
